### PR TITLE
[GPII-3624]: Improve peer discovery mechanics

### DIFF
--- a/mem3_helper.py
+++ b/mem3_helper.py
@@ -36,7 +36,7 @@ def discover_peers(service_record):
         expected_peers_count = int(expected_peers_count)
         print('Expecting', expected_peers_count, 'peers...')
     else:
-        print('Looks like COUCHDB_CLUSTER_SIZE is not set, will not wait for DNS...')
+        print('Looks like COUCHDB_CLUSTER_SIZE is not set, will not wait for DNS to fully propagate...')
     print('Resolving SRV record:', service_record)
     # Erlang requires that we drop the trailing period from the absolute DNS
     # name to form the hostname used for the Erlang node. This feels hacky

--- a/mem3_helper.py
+++ b/mem3_helper.py
@@ -31,8 +31,9 @@ def construct_service_record():
     max_tries=10
 )
 def discover_peers(service_record):
-    expected_peers_count = int(os.getenv('COUCHDB_CLUSTER_SIZE'))
+    expected_peers_count = os.getenv('COUCHDB_CLUSTER_SIZE')
     if expected_peers_count:
+        expected_peers_count = int(expected_peers_count)
         print('Expecting', expected_peers_count, 'peers...')
     else:
         print('Looks like COUCHDB_CLUSTER_SIZE is not set, will not wait for DNS...')

--- a/mem3_helper.py
+++ b/mem3_helper.py
@@ -23,12 +23,12 @@ def construct_service_record():
 @backoff.on_exception(
     backoff.expo,
     dns.resolver.NXDOMAIN,
-    max_tries=10
+    max_tries=15
 )
 @backoff.on_exception(
     backoff.expo,
     PeerDiscoveryException,
-    max_tries=10
+    max_tries=15
 )
 def discover_peers(service_record):
     expected_peers_count = os.getenv('COUCHDB_CLUSTER_SIZE')


### PR DESCRIPTION
Existing implementation of peer discovery relies entirely on cluster DNS data to populate membership.
The problem is that there are many situations when DNS data can not be trusted.

Typical failure scenario:
* Stateful set contains 2 replicas.
* First replica is ready, but second replica is still spinning up by K8s.
* Stateful set assembler is already running in first replica.
* But SRV record for `_couchdb._tcp.couchdb-couchdb.gpii.svc.cluster.local` contains only one node: `['couchdb-couchdb-0.couchdb-couchdb.gpii.svc.cluster.local']`.
* Membership is being populated with a single replica.

Istio makes this problem much worse, my understanding – sidecar injection takes time, which can delay DNS propagation even more.

Probably most straightforward way to improve the situation without dramatic changes (i.e. to use K8s API instead of cluster DNS) – set `COUCHDB_CLUSTER_SIZE` environment variable in [StatefulSet](https://github.com/gpii-ops/gpii-infra/blob/9d4bee588b03ef139cde36a2e7b4084f154cc935/shared/charts/couchdb/templates/statefulset.yaml#L98-L99) so we can wait until SRV record contains expected number of peers.